### PR TITLE
turn off Style/RaiseArgs

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -32,3 +32,6 @@ Style/IfUnlessModifier:
 
 Style/NegatedIf:
   Enabled: false
+
+Style/RaiseArgs:
+  Enabled: false


### PR DESCRIPTION
rule feels farily arbitrary since it disallows direct instantion when
there is one argument but permits it when there are multiple arguments

from https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/RaiseArgs
raise StandardError.new("message")

raise StandardError, "message"
fail "message"
raise MyCustomError.new(arg1, arg2, arg3)
raise MyKwArgError.new(key1: val1, key2: val2)