### PR TITLE
require trailing commas on multiline statements

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -35,3 +35,9 @@ Style/NegatedIf:
 
 Style/RaiseArgs:
   Enabled: false
+
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: consistent_comma
+
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: consistent_comma


### PR DESCRIPTION
makes diffs smaller and reduces errors forgetting a comma