### PR TITLE
fix 'obsolete' rule which causes rubocop to crash

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -39,5 +39,9 @@ Style/RaiseArgs:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
 
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
+  
+Style/TrailingCommaInHashLiteral
+  EnforcedStyleForMultiline: consistent_comma
+  


### PR DESCRIPTION
RuboCop::ValidationError: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
(obsolete configuration found in .rubocop-https---raw-githubusercontent-com-ParkWhiz-ruby-style-guide-master-rubocop-yml, please update it)

Praise Rubocop for giving us such flexibility!