### PR TITLE
Change style behaviour

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -62,3 +62,15 @@ Style/MultilineBlockChain:
   
 Style/SymbolArray:
   EnforcedStyle: brackets
+
+Style/WordArray:
+  EnforcedStyle: brackets
+
+Style/GuardClause:
+  Enabled: false
+
+Style/NumericPredicate:
+  EnforcedStyle: comparison
+
+Style/Lambda:
+  EnforcedStyle: literal

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -70,7 +70,7 @@ Style/GuardClause:
   Enabled: false
 
 Style/NumericPredicate:
-  EnforcedStyle: comparison
+  Enabled: false
 
 Style/Lambda:
   EnforcedStyle: literal


### PR DESCRIPTION
* Style/WordArray - require brackets, percent-string led to long lines
  and is annoying to read
* Style/GuardClause - annoying to read on long lines, often makes lines
  too long -- disabled.
* Style/NumericPredicate - it's just more clear to say `a > 0` then
  `a.positive?` What about `a >= 0`, maybe there's a predicate for that?
  I say comparison is better.
* Style/Lambda - I couldn't figure out how to make `lambda` work for
  Rails `scope' so I changed style to `literal' (`->`).