### PR TITLE
Few more changes to make compliance easier

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -17,7 +17,7 @@ Metrics/LineLength:
   Max: 100
 
 Metrics/PerceivedComplexity:
-  Max: 21
+  Max: 35
 
 Metrics/MethodLength:
   Max: 50
@@ -74,3 +74,6 @@ Style/NumericPredicate:
 
 Style/Lambda:
   EnforcedStyle: literal
+
+Naming/PredicateName:
+  Enabled: false

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -1,6 +1,9 @@
 AllCops:
   TargetRubyVersion: 2.3.3
 
+Naming/PredicateName:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 45
 
@@ -17,7 +20,7 @@ Metrics/LineLength:
   Max: 100
 
 Metrics/PerceivedComplexity:
-  Max: 35
+  Enabled: false
 
 Metrics/MethodLength:
   Max: 50
@@ -44,6 +47,9 @@ Style/NegatedIf:
 
 Style/RaiseArgs:
   Enabled: false
+
+Style/RescueStandardError:
+  EnforcedStyle: implicit
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma
@@ -74,6 +80,3 @@ Style/NumericPredicate:
 
 Style/Lambda:
   EnforcedStyle: literal
-
-Naming/PredicateName:
-  Enabled: false


### PR DESCRIPTION
* Bump Metrics/PerceivedComplexity max to something higher, we should probably disable this and let the reviewer be the judge if something's too complex
* Naming/PredicateName - I don't think that naming something as `has_one` vs `one?` is a bad thing. Sure would be annoying to change for some of our methods.

How do you guys feel about multi-line curly braces? I had to correct chained select/reject/etc statements into something like this:
```
array.select do |a|
  .....
end.reject { |b| .... }
```

I'm not sure if that's more readable then curly braces...